### PR TITLE
Fix account-map provider configuration

### DIFF
--- a/src/provider-source.tf
+++ b/src/provider-source.tf
@@ -1,5 +1,5 @@
 module "source_account_role" {
-  source = "../../../account-map/modules/iam-roles"
+  source = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=tags/v1.535.3"
 
   stage  = var.loki_stage_name
   tenant = var.loki_tenant_name

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -14,6 +14,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles"?ref=tags/v1.535.3"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=tags/v1.535.3"
   context = module.this.context
 }

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -14,6 +14,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "../../../account-map/modules/iam-roles"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles"?ref=tags/v1.535.3"
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Replace relative path for account-map module with git reference to the component

## why
* After we split monorepo we can not use relative paths for component references



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the source of a module to use a specific tagged version from a remote repository instead of a local path. No changes to configuration or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->